### PR TITLE
Remove reference to Data.Strict.Maybe

### DIFF
--- a/rose-trie.cabal
+++ b/rose-trie.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:     rose-trie
-version:  1.0.0.2
+version:  1.0.0.3
 synopsis:
     Provides "Data.Tree.RoseTrie": trees with polymorphic paths to nodes, combining
     properties of Rose Tree data structures and Trie data structures.

--- a/src/Data/Tree/RoseTrie.hs
+++ b/src/Data/Tree/RoseTrie.hs
@@ -45,7 +45,7 @@ import           Data.Foldable
 import           Data.Lens.Minimal
 import           Data.Maybe
 import           Data.Monoid
-import           Data.Strict.Maybe
+-- import           Data.Strict.Maybe
 import           Data.Typeable
 import qualified Data.Map as M
 import           Data.Traversable


### PR DESCRIPTION
The strict package (presumably the source of Data.Strict.Maybe?) is not
listed in the build-depends; however, including it causes ambiguity
errors, since Maybe is also defined in the Prelude.
